### PR TITLE
add CH dialect and use [] as array boundary

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -12,5 +12,8 @@ type Dialect interface {
 	EncodeTime(t time.Time) string
 	EncodeBytes(b []byte) string
 
+	EncodeArrayBegin() string
+	EncodeArrayEnd() string
+
 	Placeholder(n int) string
 }

--- a/dialect/clickhouse.go
+++ b/dialect/clickhouse.go
@@ -1,8 +1,6 @@
 package dialect
 
 import (
-	"fmt"
-	"strings"
 	"time"
 )
 
@@ -11,56 +9,25 @@ import (
 type clickhouse struct{}
 
 func (d clickhouse) QuoteIdent(s string) string {
-	return quoteIdent(s, "`")
+	// Following the coding convention in this repo to call
+	// methods on base object directly.
+	return MySQL.QuoteIdent(s)
 }
 
 func (d clickhouse) EncodeString(s string) string {
-	var buf strings.Builder
-
-	buf.WriteRune('\'')
-	// https://dev.mysql.com/doc/refman/5.7/en/string-literals.html
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case 0:
-			buf.WriteString(`\0`)
-		case '\'':
-			buf.WriteString(`\'`)
-		case '"':
-			buf.WriteString(`\"`)
-		case '\b':
-			buf.WriteString(`\b`)
-		case '\n':
-			buf.WriteString(`\n`)
-		case '\r':
-			buf.WriteString(`\r`)
-		case '\t':
-			buf.WriteString(`\t`)
-		case 26:
-			buf.WriteString(`\Z`)
-		case '\\':
-			buf.WriteString(`\\`)
-		default:
-			buf.WriteByte(s[i])
-		}
-	}
-
-	buf.WriteRune('\'')
-	return buf.String()
+	return MySQL.EncodeString(s)
 }
 
 func (d clickhouse) EncodeBool(b bool) string {
-	if b {
-		return "1"
-	}
-	return "0"
+	return MySQL.EncodeBool(b)
 }
 
 func (d clickhouse) EncodeTime(t time.Time) string {
-	return `'` + t.UTC().Format(timeFormat) + `'`
+	return MySQL.EncodeTime(t)
 }
 
 func (d clickhouse) EncodeBytes(b []byte) string {
-	return fmt.Sprintf(`0x%x`, b)
+	return MySQL.EncodeBytes(b)
 }
 
 func (d clickhouse) EncodeArrayBegin() string {
@@ -71,6 +38,6 @@ func (d clickhouse) EncodeArrayEnd() string {
 	return "]"
 }
 
-func (d clickhouse) Placeholder(_ int) string {
-	return "?"
+func (d clickhouse) Placeholder(p int) string {
+	return MySQL.Placeholder(p)
 }

--- a/dialect/clickhouse.go
+++ b/dialect/clickhouse.go
@@ -6,13 +6,15 @@ import (
 	"time"
 )
 
-type mysql struct{}
+// clickhouse dialect is based on mysql dialect, but using
+// [...] to represent array instead of (...).
+type clickhouse mysql
 
-func (d mysql) QuoteIdent(s string) string {
+func (d clickhouse) QuoteIdent(s string) string {
 	return quoteIdent(s, "`")
 }
 
-func (d mysql) EncodeString(s string) string {
+func (d clickhouse) EncodeString(s string) string {
 	var buf strings.Builder
 
 	buf.WriteRune('\'')
@@ -46,29 +48,29 @@ func (d mysql) EncodeString(s string) string {
 	return buf.String()
 }
 
-func (d mysql) EncodeBool(b bool) string {
+func (d clickhouse) EncodeBool(b bool) string {
 	if b {
 		return "1"
 	}
 	return "0"
 }
 
-func (d mysql) EncodeTime(t time.Time) string {
+func (d clickhouse) EncodeTime(t time.Time) string {
 	return `'` + t.UTC().Format(timeFormat) + `'`
 }
 
-func (d mysql) EncodeBytes(b []byte) string {
+func (d clickhouse) EncodeBytes(b []byte) string {
 	return fmt.Sprintf(`0x%x`, b)
 }
 
-func (d mysql) EncodeArrayBegin() string {
-	return "("
+func (d clickhouse) EncodeArrayBegin() string {
+	return "["
 }
 
-func (d mysql) EncodeArrayEnd() string {
-	return ")"
+func (d clickhouse) EncodeArrayEnd() string {
+	return "]"
 }
 
-func (d mysql) Placeholder(_ int) string {
+func (d clickhouse) Placeholder(_ int) string {
 	return "?"
 }

--- a/dialect/clickhouse.go
+++ b/dialect/clickhouse.go
@@ -8,7 +8,7 @@ import (
 
 // clickhouse dialect is based on mysql dialect, but using
 // [...] to represent array instead of (...).
-type clickhouse mysql
+type clickhouse struct{}
 
 func (d clickhouse) QuoteIdent(s string) string {
 	return quoteIdent(s, "`")

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -3,6 +3,8 @@ package dialect
 import "strings"
 
 var (
+	// ClickHouse dialect
+	ClickHouse = clickhouse{}
 	// MySQL dialect
 	MySQL = mysql{}
 	// PostgreSQL dialect

--- a/dialect/dialect_test.go
+++ b/dialect/dialect_test.go
@@ -6,6 +6,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestClickHouse(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+	}{
+		{
+			in:   "table.col",
+			want: "`table`.`col`",
+		},
+		{
+			in:   "col",
+			want: "`col`",
+		},
+	} {
+		require.Equal(t, test.want, ClickHouse.QuoteIdent(test.in))
+	}
+}
+
+func TestArrayBoundaries(t *testing.T) {
+	require.Equal(t, "[", ClickHouse.EncodeArrayBegin())
+	require.Equal(t, "]", ClickHouse.EncodeArrayEnd())
+
+	require.Equal(t, "(", MySQL.EncodeArrayBegin())
+	require.Equal(t, ")", MySQL.EncodeArrayEnd())
+}
+
 func TestMySQL(t *testing.T) {
 	for _, test := range []struct {
 		in   string

--- a/dialect/postgresql.go
+++ b/dialect/postgresql.go
@@ -32,6 +32,14 @@ func (d postgreSQL) EncodeBytes(b []byte) string {
 	return fmt.Sprintf(`E'\\x%x'`, b)
 }
 
+func (d postgreSQL) EncodeArrayBegin() string {
+	return "("
+}
+
+func (d postgreSQL) EncodeArrayEnd() string {
+	return ")"
+}
+
 func (d postgreSQL) Placeholder(n int) string {
 	return fmt.Sprintf("$%d", n+1)
 }

--- a/dialect/sqlite3.go
+++ b/dialect/sqlite3.go
@@ -35,6 +35,14 @@ func (d sqlite3) EncodeBytes(b []byte) string {
 	return fmt.Sprintf(`X'%x'`, b)
 }
 
+func (d sqlite3) EncodeArrayBegin() string {
+	return "("
+}
+
+func (d sqlite3) EncodeArrayEnd() string {
+	return ")"
+}
+
 func (d sqlite3) Placeholder(_ int) string {
 	return "?"
 }

--- a/interpolate.go
+++ b/interpolate.go
@@ -164,7 +164,7 @@ func (i *interpolator) encodePlaceholder(value interface{}, topLevel bool) error
 			// FIXME: support zero-length slice
 			return ErrInvalidSliceLength
 		}
-		i.WriteString("(")
+		i.WriteString(i.EncodeArrayBegin())
 		for n := 0; n < v.Len(); n++ {
 			if n > 0 {
 				i.WriteString(",")
@@ -174,7 +174,7 @@ func (i *interpolator) encodePlaceholder(value interface{}, topLevel bool) error
 				return err
 			}
 		}
-		i.WriteString(")")
+		i.WriteString(i.EncodeArrayEnd())
 		return nil
 	case reflect.Ptr:
 		if v.IsNil() {


### PR DESCRIPTION
Add ClickHouse dialect. 

It's fine for most cases to reuse MySQL dialect to generate CH SQLs, but for array values, we have to wrap them inside [] instead of () as done in MySQL dialect. 

For example, with MySQL dialect, we generated sth like hasAll("foo", ("v1", "v2")); but with ClickHouse dialect, it's like hasAll("foo", ["v1", "v2"]). 